### PR TITLE
Update Readme with correct clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/square/register-android-sdk.git
 cd register-android-sdk
 ```
 
-Create a `hellocharge.properties` file in the `sample-hellocharge` folder, with a `clientId` key set to [your client id](https://docs.connect.squareup.com/articles/register-api-android/#registerapisetup):
+Create a `hellocharge.properties` file in the `sample-hellocharge` folder, with a `clientId` key set to [your client id](https://docs.connect.squareup.com/articles/register-api-android/#registerapisetup) which is the same as your application id of your app (`sq0idp-XXXXXXXXXXXXXXX`)
 
 ```
 echo clientId=\"YourClientId\" > sample-hellocharge/hellocharge.properties

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/square/register-android-sdk.git
 cd register-android-sdk
 ```
 
-Create a `hellocharge.properties` file in the `sample-hellocharge` folder, with a `clientId` key set to [your client id](https://docs.connect.squareup.com/articles/register-api-android/#registerapisetup) which is the same as your application id of your app (`sq0idp-XXXXXXXXXXXXXXX`)
+Create a `hellocharge.properties` file in the `sample-hellocharge` folder, with a `clientId` key set to your application's client id which is the same as your application id in the square developer portal (`sq0idp-XXXXXXXXXXXXXXX`)
 
 ```
 echo clientId=\"YourClientId\" > sample-hellocharge/hellocharge.properties

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A sample app is available in the `sample-hellocharge` folder.
 Check out this repo:
 
 ```
-git clone git@github.com:square/register-android-sdk.git
+git clone https://github.com/square/register-android-sdk.git
 cd register-android-sdk
 ```
 


### PR DESCRIPTION
git@github.com:square/register-android-sdk.git works great if you are a member of the repository. For the rest of us the https:// prevents us from getting a `fatal: Could not read from remote repository.`