### PR TITLE
update leanback version to be similar to others

### DIFF
--- a/sample-bikeshop/build.gradle
+++ b/sample-bikeshop/build.gradle
@@ -45,7 +45,7 @@ dependencies {
   testCompile 'junit:junit:4.12'
   compile 'com.android.support:appcompat-v7:24.1.1'
   compile 'com.android.support:recyclerview-v7:24.1.1'
-  compile 'com.android.support:leanback-v17:24.1.0'
+  compile 'com.android.support:leanback-v17:24.1.1'
   compile 'com.google.code.gson:gson:2.6.2'
   compile 'com.squareup.sdk:register-sdk:1.2'
 }


### PR DESCRIPTION
If you try to build the bikeshop project, you'll fail.

```
Ran lint on variant debug: 31 issues found
Ran lint on variant release: 31 issues found
Wrote HTML report to file:///Users/tristans/Development/register-android-sdk/sample-bikeshop/build/reports/lint-results.html
Wrote XML report to file:///Users/tristans/Development/register-android-sdk/sample-bikeshop/build/reports/lint-results.xml
:sample-bikeshop:lint FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sample-bikeshop:lint'.
> Lint found errors in the project; aborting build.
  
  Fix the issues identified by lint, or add the following to your build script to proceed with errors:
  ...
  android {
      lintOptions {
          abortOnError false
      }
  }
  ...
```
Looking at the linting errors

```
GradleCompatible: Incompatible Gradle Versions
```

```
../../build.gradle: All com.android.support libraries must use the exact same version specification (mixing versions can lead to runtime crashes). Found versions 24.1.1, 24.1.0. Examples include com.android.support:animated-vector-drawable:24.1.1 and com.android.support:leanback-v17:24.1.0
```

so I updated the last one to match others so I could build. 